### PR TITLE
Fix StrangeBee account number (Issue #2)

### DIFF
--- a/aws/ug-secops-instances/variables.tf
+++ b/aws/ug-secops-instances/variables.tf
@@ -14,7 +14,7 @@ variable "secops_region" {
 
 variable "strangebee_account_number" {
   type = string
-  default = "339624944083"
+  default = "679593333241"
   description = "StrangeBee AWS account number to get AMIs from"
 }
 


### PR DESCRIPTION
Following Issue #2 (AWS | Error: Your query returned no results. Please change your search criteria and try again.), it appears the default variable used as the `strangebee_account_number` is out of date. This should fix the issue for anyone who pulls this repo in the future.